### PR TITLE
Remove test "if canImport(CryptoKit)" that forces iOS app to be >= 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,29 +7,17 @@ let packageDependencies: [PackageDescription.Package.Dependency]
 let targetDependencies: [PackageDescription.Target.Dependency]
 let supportedPlatform: [PackageDescription.SupportedPlatform]
 
-#if canImport(CryptoKit)
-    packageDependencies = [
-        .package(url: "https://github.com/FitnessKit/FitnessUnits", from: "3.1.0"),
-        .package(url: "https://github.com/FitnessKit/DataDecoder", from: "5.0.0")
-    ]
-    targetDependencies = [
-        "FitnessUnits",
-        "DataDecoder"
-    ]
-    supportedPlatform = [.iOS("13.0"), .macOS("10.15"), .tvOS("13.0"), .watchOS("6.0")]
-#else
-    packageDependencies = [
-        .package(url: "https://github.com/FitnessKit/FitnessUnits", from: "3.1.0"),
-        .package(url: "https://github.com/FitnessKit/DataDecoder", from: "5.0.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "1.0.0")
-    ]
-    targetDependencies = [
-        "FitnessUnits",
-        "DataDecoder",
-        "CryptoSwift",
-    ]
-    supportedPlatform = [.iOS("10.0"), .macOS("10.12"), .tvOS("10.0"), .watchOS("3.0")]
-#endif
+packageDependencies = [
+    .package(url: "https://github.com/FitnessKit/FitnessUnits", from: "3.1.0"),
+    .package(url: "https://github.com/FitnessKit/DataDecoder", from: "5.0.0"),
+    .package(url: "https://github.com/krzyzanowskim/CryptoSwift", from: "1.0.0")
+]
+targetDependencies = [
+    "FitnessUnits",
+    "DataDecoder",
+    "CryptoSwift",
+]
+supportedPlatform = [.iOS("10.0"), .macOS("10.12"), .tvOS("10.0"), .watchOS("3.0")]
 
 let package = Package(
     name: "BluetoothMessageProtocol",


### PR DESCRIPTION
Hi,

On "Package.swift", I removed the test :
`#if canImport(CryptoKit)`

The reason, is that if you run a project targeting iOS<13 and import BluetoothMessageProtocol via SPM, we get the following error:

```
dyld: Library not loaded: /System/Library/Frameworks/CryptoKit.framework/CryptoKit
  Referenced from: /Users/nicolasbush/Library/Developer/CoreSimulator/Devices/9F6677E3-86A0-4B26-88C7-DFE0AEA57851/data/Containers/Bundle/Application/E43C443F-4AF0-4CCB-AA0C-ECAA2A2769AA/TestBMP.app/TestBMP
  Reason: image not found
```

So, I guess, it's better to import CryptoSwift all the time (even if it's unused for iOS>=13) and be compatible with iOS >=10 

